### PR TITLE
Acessibilidade: adicionado "lang="pt" na tag <html>

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="pt">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">


### PR DESCRIPTION
Ausência de descrição de linguagem na tag <html> leva leitores de tela, usado por pessoas que tem deficiência visual, a ter uma experiencia pior ao ouvir uma voz com sotaque em inglês em vez de em português. Esse commit resolve isso
